### PR TITLE
Parse --json option as json

### DIFF
--- a/homeassistant_cli/plugins/event.py
+++ b/homeassistant_cli/plugins/event.py
@@ -36,7 +36,7 @@ def fire(ctx: Configuration, event, json):
     """Fire event in Home Assistant."""
     if json:
         click.echo("Fire {}".format(event))
-        response = api.fire_event(ctx, event, json)
+        response = api.fire_event(ctx, event, json_.loads(json))
     else:
         existing = raw_format_output(ctx.output, [{}], ctx.yaml())
         new = click.edit(existing, extension='.{}'.format(ctx.output))


### PR DESCRIPTION
I tried to fire an event and noticed that the --json argument content is passed as a string to home assistant, which returns the error: 400 - {"message": "Event data should be a JSON object"}

This PR converts the option into a JSON object.

Example call: `hass-cli event fire MY_EVENT --json '{"foo": "bar"}'`