### PR TITLE
show area name instead of id on device list

### DIFF
--- a/homeassistant_cli/plugins/area.py
+++ b/homeassistant_cli/plugins/area.py
@@ -37,9 +37,9 @@ def listcmd(ctx: Configuration, areafilter: str):
     else:
         areafilterre = re.compile(areafilter)  # type: Pattern
 
-        for device in areas:
-            if areafilterre.search(device['name']):
-                result.append(device)
+        for area in areas:
+            if areafilterre.search(area['name']):
+                result.append(area)
 
     cols = [('ID', 'area_id'), ('NAME', 'name')]
 

--- a/homeassistant_cli/plugins/device.py
+++ b/homeassistant_cli/plugins/device.py
@@ -28,6 +28,8 @@ def listcmd(ctx: Configuration, devicefilter: str):
     """List all devices from Home Assistant."""
     ctx.auto_output("table")
 
+    areas = api.get_areas(ctx)
+
     devices = api.get_devices(ctx)
 
     result = []  # type: List[Dict]
@@ -40,12 +42,19 @@ def listcmd(ctx: Configuration, devicefilter: str):
             if devicefilterre.search(device['name']):
                 result.append(device)
 
+    for device in devices:
+        area = next(
+            (a for a in areas if a['area_id'] == device['area_id']), None
+        )
+        if area:
+            device['area_name'] = area['name']
+
     cols = [
         ('ID', 'id'),
         ('NAME', 'name'),
         ('MODEL', 'model'),
         ('MANUFACTURER', 'manufacturer'),
-        ('AREA', 'area_id'),
+        ('AREA', 'area_name'),
     ]
 
     ctx.echo(


### PR DESCRIPTION
I was looking at the device list and seeing the area ids seemed not so useful so I changed it to show the area name instead. I haven't done a lot of python so if there's a more idiomatic way to do this I'm happy to change it. 😄 