### PR TITLE
Support `--output ndjson`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -460,7 +460,7 @@ Help
                                       environment variable HASS_PASSWORD.
       --timeout INTEGER               Timeout for network operations.  [default:
                                       5]
-      -o, --output [json|yaml|table|auto]
+      -o, --output [json|yaml|table|ndjson|auto]
                                       Output format.  [default: auto]
       -v, --verbose                   Enables verbose mode.
       -x                              Print backtraces when exception occurs.

--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -143,7 +143,7 @@ def _default_token() -> Optional[str]:
     '--output',
     '-o',
     help="Output format.",
-    type=click.Choice(['json', 'yaml', 'table', 'auto']),
+    type=click.Choice(['json', 'yaml', 'table', 'auto', 'ndjson']),
     default='auto',
     show_default=True,
 )

--- a/homeassistant_cli/helper.py
+++ b/homeassistant_cli/helper.py
@@ -68,6 +68,11 @@ def raw_format_output(
             return json.dumps(data, indent=2, sort_keys=False)
         except ValueError:
             return str(data)
+    elif output == 'ndjson':
+        try:
+            return json.dumps(data)
+        except ValueError:
+            return str(data)
     elif output == 'yaml':
         try:
             return cast(str, yaml.dumpyaml(yamlparser, data))


### PR DESCRIPTION
Hello!

I found myself wanting to run something like `hass-cli event watch | grep ... | jq ...` and it was more complicated than I would have liked because of the format, so I added a flag to allow [ndjson](http://ndjson.org/) as an output format, which makes things like that much easier...