### PR TITLE
prevent list command shadowing builtin

### DIFF
--- a/homeassistant_cli/hassconst.py
+++ b/homeassistant_cli/hassconst.py
@@ -609,6 +609,7 @@ URL_API_COMPONENTS = "/api/components"
 URL_API_ERROR_LOG = "/api/error_log"
 URL_API_LOG_OUT = "/api/log_out"
 URL_API_TEMPLATE = "/api/template"
+URL_API_HISTORY_PERIOD = "/api/history/period"
 
 HTTP_OK = 200
 HTTP_CREATED = 201

--- a/homeassistant_cli/plugins/state.py
+++ b/homeassistant_cli/plugins/state.py
@@ -67,7 +67,7 @@ def delete(ctx: Configuration, entity):
 @cli.command('list')
 @click.argument('entityfilter', default=".*", required=False)
 @pass_context
-def list(ctx, entityfilter):
+def list_command(ctx, entityfilter):
     """List all state from Home Assistant."""
     ctx.auto_output("table")
     states = api.get_states(ctx)


### PR DESCRIPTION
Fix error with state history, eg

```
hass-cli --server=http://homeassistant:8123 --sort-by last_changed -l DEBUG state history --since 50m group.g_present
```

Fixes #332 - `list` function shadows built-in python version
