### PR TITLE
fix: #384 #382 change deprecated parameter name autocompletion

### DIFF
--- a/homeassistant_cli/cli.py
+++ b/homeassistant_cli/cli.py
@@ -198,7 +198,7 @@ def _default_token() -> Optional[str]:
     '--table-format',
     default='plain',
     help="Which table format to use.",
-    autocompletion=autocompletion.table_formats,
+    shell_complete=autocompletion.table_formats,
 )
 @click.option(
     '--sort-by',

--- a/homeassistant_cli/plugins/area.py
+++ b/homeassistant_cli/plugins/area.py
@@ -77,7 +77,7 @@ def create(ctx, names):
     'names',
     nargs=-1,
     required=True,
-    autocompletion=autocompletion.areas,  # type: ignore
+    shell_complete=autocompletion.areas,  # type: ignore
 )
 @pass_context
 def delete(ctx, names):
@@ -114,7 +114,7 @@ def delete(ctx, names):
 @click.argument(
     'oldname',
     required=True,
-    autocompletion=autocompletion.areas,  # type: ignore
+    shell_complete=autocompletion.areas,  # type: ignore
 )
 @click.argument('newname', required=True)
 @pass_context

--- a/homeassistant_cli/plugins/device.py
+++ b/homeassistant_cli/plugins/device.py
@@ -68,7 +68,7 @@ def listcmd(ctx: Configuration, devicefilter: str):
 @click.argument(
     'area_id_or_name',
     required=True,
-    autocompletion=autocompletion.areas,  # type: ignore
+    shell_complete=autocompletion.areas,  # type: ignore
 )
 @click.argument('names', nargs=-1, required=False)
 @click.option(

--- a/homeassistant_cli/plugins/entity.py
+++ b/homeassistant_cli/plugins/entity.py
@@ -71,7 +71,7 @@ def listcmd(ctx: Configuration, entityfilter: str):
 @click.argument(
     'area_id_or_name',
     required=True,
-    autocompletion=autocompletion.areas,  # type: ignore
+    shell_complete=autocompletion.areas,  # type: ignore
 )
 @click.argument('names', nargs=-1, required=False)
 @click.option(
@@ -151,13 +151,13 @@ def assign(
 @click.argument(
     'oldid',
     required=True,
-    autocompletion=autocompletion.entities,  # type: ignore
+    shell_complete=autocompletion.entities,  # type: ignore
 )
 @click.option('--name', required=False)
 @click.argument(
     'newid',
     required=False,
-    autocompletion=autocompletion.entities,  # type: ignore
+    shell_complete=autocompletion.entities,  # type: ignore
 )
 @pass_context
 def rename(ctx, oldid, newid, name):

--- a/homeassistant_cli/plugins/event.py
+++ b/homeassistant_cli/plugins/event.py
@@ -25,7 +25,7 @@ def cli(ctx):
 @click.argument(
     'event',
     required=True,
-    autocompletion=autocompletion.events,  # type: ignore
+    shell_complete=autocompletion.events,  # type: ignore
 )
 @click.option(
     '--json',

--- a/homeassistant_cli/plugins/map.py
+++ b/homeassistant_cli/plugins/map.py
@@ -23,7 +23,7 @@ SERVICE = {
 @click.argument(
     'entity',
     required=False,
-    autocompletion=autocompletion.entities,  # type: ignore
+    shell_complete=autocompletion.entities,  # type: ignore
 )
 @click.option(
     '--service', default='openstreetmap', type=click.Choice(SERVICE.keys())

--- a/homeassistant_cli/plugins/raw.py
+++ b/homeassistant_cli/plugins/raw.py
@@ -42,7 +42,7 @@ def _report(ctx, cmd, method, response) -> None:
 
 @cli.command()
 @click.argument(
-    'method', autocompletion=autocompletion.api_methods  # type: ignore
+    'method', shell_complete=autocompletion.api_methods  # type: ignore
 )
 @pass_context
 def get(ctx: Configuration, method):
@@ -54,7 +54,7 @@ def get(ctx: Configuration, method):
 
 @cli.command()
 @click.argument(
-    'method', autocompletion=autocompletion.api_methods  # type: ignore
+    'method', shell_complete=autocompletion.api_methods  # type: ignore
 )
 @click.option('--json')
 @pass_context
@@ -72,7 +72,7 @@ def post(ctx: Configuration, method, json):
 
 @cli.command("ws")
 @click.argument(
-    'wstype', autocompletion=autocompletion.wsapi_methods  # type: ignore
+    'wstype', shell_complete=autocompletion.wsapi_methods  # type: ignore
 )
 @click.option('--json')
 @pass_context

--- a/homeassistant_cli/plugins/service.py
+++ b/homeassistant_cli/plugins/service.py
@@ -80,7 +80,7 @@ def list_cmd(ctx: Configuration, servicefilter):
 @click.argument(
     'service',
     required=True,
-    autocompletion=autocompletion.services,  # type: ignore
+    shell_complete=autocompletion.services,  # type: ignore
 )
 @click.option(
     '--arguments', help="Comma separated key/value pairs to use as arguments."

--- a/homeassistant_cli/plugins/state.py
+++ b/homeassistant_cli/plugins/state.py
@@ -26,7 +26,7 @@ def cli(ctx):
 @click.argument(
     'entity',
     required=True,
-    autocompletion=autocompletion.entities,  # type: ignore
+    shell_complete=autocompletion.entities,  # type: ignore
 )
 @pass_context
 def get(ctx: Configuration, entity):
@@ -50,7 +50,7 @@ def get(ctx: Configuration, entity):
 @click.argument(
     'entity',
     required=True,
-    autocompletion=autocompletion.entities,  # type: ignore
+    shell_complete=autocompletion.entities,  # type: ignore
 )
 @pass_context
 def delete(ctx: Configuration, entity):
@@ -95,7 +95,7 @@ def list_command(ctx, entityfilter):
 @click.argument(
     'entity',
     required=True,
-    autocompletion=autocompletion.entities,  # type: ignore
+    shell_complete=autocompletion.entities,  # type: ignore
 )
 @click.argument('newstate', required=False)
 @click.option(
@@ -207,7 +207,7 @@ def _homeassistant_cmd(ctx: Configuration, entities, cmd, action):
     'entities',
     nargs=-1,
     required=True,
-    autocompletion=autocompletion.entities,  # type: ignore
+    shell_complete=autocompletion.entities,  # type: ignore
 )
 @pass_context
 def toggle(ctx: Configuration, entities):
@@ -221,7 +221,7 @@ def toggle(ctx: Configuration, entities):
     'entities',
     nargs=-1,
     required=True,
-    autocompletion=autocompletion.entities,  # type: ignore
+    shell_complete=autocompletion.entities,  # type: ignore
 )
 @pass_context
 def off_cmd(ctx: Configuration, entities):
@@ -235,7 +235,7 @@ def off_cmd(ctx: Configuration, entities):
     'entities',
     nargs=-1,
     required=True,
-    autocompletion=autocompletion.entities,  # type: ignore
+    shell_complete=autocompletion.entities,  # type: ignore
 )
 @pass_context
 def on_cmd(ctx: Configuration, entities):
@@ -249,7 +249,7 @@ def on_cmd(ctx: Configuration, entities):
     'entities',
     nargs=-1,
     required=True,
-    autocompletion=autocompletion.entities,  # type: ignore
+    shell_complete=autocompletion.entities,  # type: ignore
 )
 @click.option(
     '--since',


### PR DESCRIPTION
# Context

Click has deprecated the parameter name `autocompletion` in favor of the new name `shell_complete` as of version 8.1.0. From the [changelog](https://click.palletsprojects.com/en/8.1.x/changes/#version-8-1-0), we have

> `autocompletion` parameter to Command is renamed to `shell_complete`.

This caused issue #384, which is also reported in #382.

This PR implements the change in parameter name to stay compatible with click.