### PR TITLE
Allow later tabulate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ REQUIRES = [
     'regex>=2022.9',
     'ruamel.yaml>=0.17,<0.18',
     'requests>=2.28.0,<3',
-    'tabulate>=0.8.3,<0.9',
+    'tabulate>=0.8.3,<0.10',
 ]
 
 # Should be as close to Home Assistant dev/master as possible


### PR DESCRIPTION
The [`tabulate` package](https://pypi.org/project/tabulate/) has released version 0.9. This version is excluded with a preemptive upper bound:

https://github.com/home-assistant-ecosystem/home-assistant-cli/blob/341c45491c8b126f1db2b5f70b820d2821e4aec9/setup.py#L92

Based on the upstream [release notes](https://github.com/astanin/python-tabulate/blob/v0.9.0/CHANGELOG):

```
- 0.9.0: Drop support for Python 2.7, 3.5, 3.6.
  Migrate to pyproject.toml project layout (PEP 621).
  New output formats: `asciidoc`, various `*grid` and `*outline` formats.
  New output features: vertical row alignment, separating lines.
  New input format: list of dataclasses (Python 3.7 or later).
  Support infinite iterables as row indices.
  Improve column width options.
  Improve support for ANSI escape sequences and document the behavior.
  Various bug fixes.
```

…it appears no intentional breaking changes should be expected in this release, and it should be safe to loosen the dependency version specification. I tried doing this and found all the tests still passed.