### PR TITLE
Fix completions

### DIFF
--- a/homeassistant_cli/autocompletion.py
+++ b/homeassistant_cli/autocompletion.py
@@ -233,7 +233,9 @@ def api_methods(
 
     for name, value in getmembers(hassconst):
         if name.startswith('URL_API_'):
-            CompletionItem(value=value, help=name[len('URL_API_') :])
+            completions.append(
+                CompletionItem(value=value, help=name[len('URL_API_') :])
+            )
 
     completions.sort(key=lambda x: x.value)
 

--- a/homeassistant_cli/autocompletion.py
+++ b/homeassistant_cli/autocompletion.py
@@ -45,7 +45,7 @@ def _init_ctx(ctx: Configuration) -> None:
 
 def services(
     ctx: Configuration, args: List, incomplete: str
-) -> List[Tuple[str, str]]:
+) -> List[CompletionItem]:
     """Services."""
     _init_ctx(ctx)
     try:

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -23,10 +23,10 @@ def test_entity_completion(basic_entities_text) -> None:
         )
         assert len(result) == 3
 
-        resultdict = dict(result)
+        resultdict = {x.value: x.help for x in result}
 
         assert "sensor.one" in resultdict
-        assert resultdict['sensor.one'] == 'friendly long name'
+        assert resultdict['sensor.one'] == 'friendly long name [on]'
 
 
 def test_service_completion(default_services_text) -> None:
@@ -45,33 +45,33 @@ def test_service_completion(default_services_text) -> None:
         )
         assert len(result) == 12
 
-        resultdict = dict(result)
+        resultdict = {x.value: x.help for x in result}
 
         assert "group.remove" in resultdict
         val = resultdict["group.remove"]
         assert val == "Remove a user group."
 
 
-def test_event_completion(default_events_text) -> None:
-    """Test completion for events."""
-    with requests_mock.Mocker() as mock:
-        mock.get(
-            'http://localhost:8123/api/events',
-            text=default_events_text,
-            status_code=200,
-        )
+# def test_event_completion(default_events_text) -> None:
+#     """Test completion for events."""
+#     with requests_mock.Mocker() as mock:
+#         mock.get(
+#             'http://localhost:8123/api/events',
+#             text=default_events_text,
+#             status_code=200,
+#         )
 
-        cfg = cli.cli.make_context('hass-cli', ['events', 'list'])
+#         cfg = cli.cli.make_context('hass-cli', ['events', 'list'])
 
-        result = autocompletion.events(
-            cfg, ["events", "list"], ""  # type: ignore
-        )
-        assert len(result) == 11
+#         result = autocompletion.events(
+#             cfg, ["events", "list"], ""  # type: ignore
+#         )
+#         assert len(result) == 11
 
-        resultdict = dict(result)
+#         resultdict = dict(result)
 
-        assert "component_loaded" in resultdict
-        assert resultdict["component_loaded"] == ""
+#         assert "component_loaded" in resultdict
+#         assert resultdict["component_loaded"] == ""
 
 
 def test_area_completion(default_events_text) -> None:
@@ -90,7 +90,7 @@ def test_area_completion(default_events_text) -> None:
         )
         assert len(result) == 11
 
-        resultdict = dict(result)
+        resultdict = {x.value: x.help for x in result}
 
         assert "component_loaded" in resultdict
-        assert resultdict["component_loaded"] == ""
+        assert resultdict["component_loaded"] is None

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -52,26 +52,26 @@ def test_service_completion(default_services_text) -> None:
         assert val == "Remove a user group."
 
 
-# def test_event_completion(default_events_text) -> None:
-#     """Test completion for events."""
-#     with requests_mock.Mocker() as mock:
-#         mock.get(
-#             'http://localhost:8123/api/events',
-#             text=default_events_text,
-#             status_code=200,
-#         )
+def test_event_completion(default_events_text) -> None:
+    """Test completion for events."""
+    with requests_mock.Mocker() as mock:
+        mock.get(
+            'http://localhost:8123/api/events',
+            text=default_events_text,
+            status_code=200,
+        )
 
-#         cfg = cli.cli.make_context('hass-cli', ['events', 'list'])
+        cfg = cli.cli.make_context('hass-cli', ['events', 'list'])
 
-#         result = autocompletion.events(
-#             cfg, ["events", "list"], ""  # type: ignore
-#         )
-#         assert len(result) == 11
+        result = autocompletion.events(
+            cfg, ["events", "list"], ""  # type: ignore
+        )
+        assert len(result) == 11
 
-#         resultdict = dict(result)
+        resultdict = {x.value: x.help for x in result}
 
-#         assert "component_loaded" in resultdict
-#         assert resultdict["component_loaded"] == ""
+        assert "component_loaded" in resultdict
+        assert resultdict["component_loaded"] is None
 
 
 def test_area_completion(default_events_text) -> None:

--- a/tests/test_completion.py
+++ b/tests/test_completion.py
@@ -74,23 +74,23 @@ def test_event_completion(default_events_text) -> None:
         assert resultdict["component_loaded"] is None
 
 
-def test_area_completion(default_events_text) -> None:
+def test_area_completion(default_areas_text) -> None:
     """Test completion for Area."""
     with requests_mock.Mocker() as mock:
         mock.get(
-            'http://localhost:8123/api/events',
-            text=default_events_text,
+            'http://localhost:8123/api/areas',
+            text=default_areas_text,
             status_code=200,
         )
 
-        cfg = cli.cli.make_context('hass-cli', ['events', 'list'])
+        cfg = cli.cli.make_context('hass-cli', ['area', 'list'])
 
-        result = autocompletion.events(
-            cfg, ["events", "list"], ""  # type: ignore
+        result = autocompletion.areas(
+            cfg, ["area", "list"], ""  # type: ignore
         )
-        assert len(result) == 11
+        assert len(result) == 3
 
         resultdict = {x.value: x.help for x in result}
 
-        assert "component_loaded" in resultdict
-        assert resultdict["component_loaded"] is None
+        assert "Bedroom" in resultdict
+        assert resultdict["Bedroom"] == "3"

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -58,7 +58,7 @@ def test_apimethod_completion(default_services) -> None:
     result = autocompletion.api_methods(cfg, ["raw", "get"], "/api/disc")
     assert len(result) == 1
 
-    resultdict = dict(result)
+    resultdict = {x.value: x.help for x in result}
 
     assert "/api/discovery_info" in resultdict
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -65,7 +65,7 @@ def test_service_completion(default_services) -> None:
         )
         assert len(result) == 2
 
-        resultdict = dict(result)
+        resultdict = {x.value: x.help for x in result}
 
         assert "light.turn_on" in resultdict
         assert "light.turn_off" in resultdict


### PR DESCRIPTION
This fixes the following:

```shell
hass-cli service call <TAB>
'tuple' object has no attribute 'type'Traceback (most recent call last):
  File "/home/pschmitt/.local/share/zinit/plugins/home-assistant-ecosystem---home-assistant-cli/homeassistant_cli/cli.py", line 40, in run
    result = cli.main(standalone_mode=False)
  File "/home/pschmitt/.local/pipx/venvs/homeassistant-cli/lib/python3.10/site-packages/click/core.py", line 1050, in main
    self._main_shell_completion(extra, prog_name, complete_var)
  File "/home/pschmitt/.local/pipx/venvs/homeassistant-cli/lib/python3.10/site-packages/click/core.py", line 1125, in _main_shell_completion
    rv = shell_complete(self, ctx_args, prog_name, complete_var, instruction)
  File "/home/pschmitt/.local/pipx/venvs/homeassistant-cli/lib/python3.10/site-packages/click/shell_completion.py", line 49, in shell_complete
    echo(comp.complete())
  File "/home/pschmitt/.local/pipx/venvs/homeassistant-cli/lib/python3.10/site-packages/click/shell_completion.py", line 292, in complete
    out = [self.format_completion(item) for item in completions]
  File "/home/pschmitt/.local/pipx/venvs/homeassistant-cli/lib/python3.10/site-packages/click/shell_completion.py", line 292, in <listcomp>
    out = [self.format_completion(item) for item in completions]
  File "/home/pschmitt/.local/pipx/venvs/homeassistant-cli/lib/python3.10/site-packages/click/shell_completion.py", line 364, in format_completion
    return f"{item.type}\n{item.value}\n{item.help if item.help else '_'}
```

Click Completions should now return `CompletionItem` instances, instead of tuples.

Ref: https://github.com/pallets/click/blob/8.1.3/docs/shell-completion.rst#custom-type-completion