### PR TITLE
fix `hass-cli state history --since .... ` by correcting the URL_API_HISTORY_PERIOD constant

### DIFF
--- a/homeassistant_cli/hassconst.py
+++ b/homeassistant_cli/hassconst.py
@@ -609,7 +609,7 @@ URL_API_COMPONENTS = "/api/components"
 URL_API_ERROR_LOG = "/api/error_log"
 URL_API_LOG_OUT = "/api/log_out"
 URL_API_TEMPLATE = "/api/template"
-URL_API_HISTORY_PERIOD = "/api/history/period"
+URL_API_HISTORY_PERIOD = "/api/history/period/{}"
 
 HTTP_OK = 200
 HTTP_CREATED = 201


### PR DESCRIPTION
This fixes a key bug with `hass-cli state history --since '.....'`.  The bug is that it ignores the value of `--since` completely.


The trouble is that [`.format()` is being used here](https://github.com/home-assistant-ecosystem/home-assistant-cli/blob/f65f9d98e92928000d2c6608b687db51414055b6/homeassistant_cli/remote.py#L362) on the `URL_API_HISTORY_PERIOD` constant, but because the constant contains no `{}` nothing actually changes. This means that the `start_time` being passed in is just completely ignored.  This PR just fixes that to work as intended.


Perviously it would always make a request to `/api/history/period?...` instead of `/api/history/period/<start_time>?....`

I'm guessing it used to work but this was lost in a refactor.

