### PR TITLE
Increase websocket max message size to 16MB

### DIFF
--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -105,7 +105,8 @@ def wsapi(
     async def fetcher() -> Optional[Dict]:
         async with aiohttp.ClientSession() as session:
             async with session.ws_connect(
-                resolve_server(ctx) + "/api/websocket"
+                resolve_server(ctx) + "/api/websocket",
+                max_msg_size=16 * 1024 * 1024,  # 16MB to handle large responses
             ) as wsconn:
 
                 await wsconn.send_str(


### PR DESCRIPTION
Set the max_msg_size parameter in aiohttp's ws_connect to 16MB (up from 4MB default) to support handling large websocket responses from the Home Assistant server. In my case this fixes `hass-cli entity list` which was giving an error due to homeassistant returning a 4.9MB response. fixes #429 