### PR TITLE
Fix websocket failure for large entity registries

### DIFF
--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -105,7 +105,8 @@ def wsapi(
     async def fetcher() -> Optional[Dict]:
         async with aiohttp.ClientSession() as session:
             async with session.ws_connect(
-                resolve_server(ctx) + "/api/websocket"
+                resolve_server(ctx) + "/api/websocket",
+                max_msg_size=16 * 1024 * 1024,
             ) as wsconn:
 
                 await wsconn.send_str(


### PR DESCRIPTION
Increases the aiohttp ws_connect max_msg_size from the default 4 MB to 16 MB. Without this, installations with large entity registries (6+ MB responses) hit a silent websocket error, causing entity list and other WS-based commands to fail with a NoneType error.