### PR TITLE
Fix --insecure by using session for requests

### DIFF
--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -81,9 +81,9 @@ def restapi(
 
     try:
         if method == METH_GET:
-            return requests.get(url, params=data_str, headers=headers)
+            return ctx.session.get(url, params=data_str, headers=headers)
 
-        return requests.request(method, url, data=data_str, headers=headers)
+        return ctx.session.request(method, url, data=data_str, headers=headers)
 
     except requests.exceptions.ConnectionError:
         raise HomeAssistantCliError(f"Error connecting to {url}") from None
@@ -124,9 +124,9 @@ def restapi_supervisor(
 
     try:
         if method == METH_GET:
-            return requests.get(url, params=data_str, headers=headers)
+            return ctx.session.get(url, params=data_str, headers=headers)
 
-        return requests.request(method, url, data=data_str, headers=headers)
+        return ctx.session.request(method, url, data=data_str, headers=headers)
 
     except requests.exceptions.ConnectionError:
         raise HomeAssistantCliError(f"Error connecting to {url}") from None


### PR DESCRIPTION
Hello,
d2e6d71 introduced a session to share verify/cert settings but kept calling requests.get/request() directly instead of ctx.session.get/request(), making session.verify a no-op.

Fix by using ctx.session for all requests so session.verify = not ctx.insecure actually takes effect.

Fixes: #184

