### PR TITLE
Add dashboard plugin with list, get and set commands

### DIFF
--- a/homeassistant_cli/hassconst.py
+++ b/homeassistant_cli/hassconst.py
@@ -619,6 +619,8 @@ URL_API_LOVELACE_CONFIG = "/api/lovelace/config"
 WS_TYPE_LOVELACE_DASHBOARDS_LIST = "lovelace/dashboards/list"
 WS_TYPE_LOVELACE_CONFIG_GET = "lovelace/config"
 WS_TYPE_LOVELACE_CONFIG_SAVE = "lovelace/config/save"
+WS_TYPE_LOVELACE_DASHBOARDS_CREATE = "lovelace/dashboards/create"
+WS_TYPE_LOVELACE_DASHBOARDS_DELETE = "lovelace/dashboards/delete"
 
 HTTP_OK = 200
 HTTP_CREATED = 201

--- a/homeassistant_cli/hassconst.py
+++ b/homeassistant_cli/hassconst.py
@@ -617,6 +617,8 @@ URL_API_TEMPLATE = "/api/template"
 URL_API_HISTORY_PERIOD = "/api/history/period/{}"
 URL_API_LOVELACE_CONFIG = "/api/lovelace/config"
 WS_TYPE_LOVELACE_DASHBOARDS_LIST = "lovelace/dashboards/list"
+WS_TYPE_LOVELACE_CONFIG_GET = "lovelace/config"
+WS_TYPE_LOVELACE_CONFIG_SAVE = "lovelace/config/save"
 
 HTTP_OK = 200
 HTTP_CREATED = 201

--- a/homeassistant_cli/hassconst.py
+++ b/homeassistant_cli/hassconst.py
@@ -615,6 +615,8 @@ URL_API_ERROR_LOG = "/api/error_log"
 URL_API_LOG_OUT = "/api/log_out"
 URL_API_TEMPLATE = "/api/template"
 URL_API_HISTORY_PERIOD = "/api/history/period/{}"
+URL_API_LOVELACE_CONFIG = "/api/lovelace/config"
+WS_TYPE_LOVELACE_DASHBOARDS_LIST = "lovelace/dashboards/list"
 
 HTTP_OK = 200
 HTTP_CREATED = 201

--- a/homeassistant_cli/plugins/dashboard.py
+++ b/homeassistant_cli/plugins/dashboard.py
@@ -72,9 +72,5 @@ def set_cmd(ctx: Configuration, filename: str, url_path: str) -> None:
         _LOGGING.error("Failed to read %s: %s", filename, err)
         sys.exit(1)
 
-    result = api.save_dashboard_config(ctx, dict(config), url_path)
-    if result.status_code in (200, 201):
-        _LOGGING.info("Dashboard uploaded successfully")
-    else:
-        _LOGGING.error("Failed (%s): %s", result.status_code, result.text)
-        sys.exit(1)
+    api.save_dashboard_config(ctx, dict(config), url_path)
+    _LOGGING.info("Dashboard uploaded successfully")

--- a/homeassistant_cli/plugins/dashboard.py
+++ b/homeassistant_cli/plugins/dashboard.py
@@ -72,5 +72,36 @@ def set_cmd(ctx: Configuration, filename: str, url_path: str) -> None:
         _LOGGING.error("Failed to read %s: %s", filename, err)
         sys.exit(1)
 
+    if url_path:
+        existing = {d["url_path"] for d in api.get_dashboards(ctx)}
+        if url_path not in existing:
+            title = config.get("title", url_path) if isinstance(config, dict) else url_path
+            _LOGGING.info("Dashboard '%s' not found, creating it", url_path)
+            api.create_dashboard(ctx, url_path, title)
+
     api.save_dashboard_config(ctx, dict(config), url_path)
     _LOGGING.info("Dashboard uploaded successfully")
+
+
+@cli.command("delete")
+@click.argument("url_path", required=True)
+@click.option(
+    "--confirm",
+    is_flag=True,
+    default=False,
+    help="Confirm deletion without prompting",
+)
+@pass_context
+def delete(ctx: Configuration, url_path: str, confirm: bool) -> None:
+    """Delete a dashboard.
+
+    URL_PATH - the url_path of the dashboard to delete
+    """
+    if not confirm:
+        click.confirm(
+            f"Are you sure you want to delete dashboard '{url_path}'?",
+            abort=True,
+        )
+
+    api.delete_dashboard(ctx, url_path)
+    _LOGGING.info("Dashboard '%s' deleted successfully", url_path)

--- a/homeassistant_cli/plugins/dashboard.py
+++ b/homeassistant_cli/plugins/dashboard.py
@@ -75,7 +75,9 @@ def set_cmd(ctx: Configuration, filename: str, url_path: str) -> None:
     if url_path:
         existing = {d["url_path"] for d in api.get_dashboards(ctx)}
         if url_path not in existing:
-            title = config.get("title", url_path) if isinstance(config, dict) else url_path
+            title = (
+                config.get("title", url_path) if isinstance(config, dict) else url_path
+            )
             _LOGGING.info("Dashboard '%s' not found, creating it", url_path)
             api.create_dashboard(ctx, url_path, title)
 

--- a/homeassistant_cli/plugins/dashboard.py
+++ b/homeassistant_cli/plugins/dashboard.py
@@ -1,0 +1,80 @@
+"""Dashboard plugin for Home Assistant CLI (hass-cli)."""
+
+import logging
+import sys
+
+import click
+from ruamel.yaml import YAML
+
+import homeassistant_cli.helper as helper
+import homeassistant_cli.remote as api
+from homeassistant_cli.cli import pass_context
+from homeassistant_cli.config import Configuration
+
+_LOGGING = logging.getLogger(__name__)
+
+COLUMNS = [
+    ("URL PATH", "url_path"),
+    ("TITLE", "title"),
+    ("MODE", "mode"),
+    ("SIDEBAR", "show_in_sidebar"),
+    ("ICON", "icon"),
+]
+
+
+@click.group("dashboard")
+@pass_context
+def cli(ctx: Configuration) -> None:
+    """Get info and manage dashboards from Home Assistant."""
+
+
+@cli.command("list")
+@pass_context
+def listcmd(ctx: Configuration) -> None:
+    """List all dashboards."""
+    ctx.auto_output("table")
+    dashboards = api.get_dashboards(ctx)
+    ctx.echo(
+        helper.format_output(
+            ctx, dashboards, columns=ctx.columns if ctx.columns else COLUMNS
+        )
+    )
+
+
+@cli.command("get")
+@click.argument("url_path", default="", required=False)
+@pass_context
+def get(ctx: Configuration, url_path: str) -> None:
+    """Get a dashboard config.
+
+    URL_PATH - optional url_path of a named dashboard (omit for default)
+    """
+    ctx.auto_output("json")
+    config = api.get_dashboard_config(ctx, url_path)
+    ctx.echo(helper.format_output(ctx, config))
+
+
+@cli.command("set")
+@click.argument("filename", type=click.Path(exists=True, dir_okay=False))
+@click.argument("url_path", default="", required=False)
+@pass_context
+def set_cmd(ctx: Configuration, filename: str, url_path: str) -> None:
+    """Set a dashboard config from a YAML or JSON file.
+
+    FILENAME - path to the config file
+    URL_PATH - optional url_path of a named dashboard (omit for default)
+    """
+    yaml = YAML()
+    try:
+        with open(filename) as f:
+            config = yaml.load(f)
+    except Exception as err:
+        _LOGGING.error("Failed to read %s: %s", filename, err)
+        sys.exit(1)
+
+    result = api.save_dashboard_config(ctx, dict(config), url_path)
+    if result.status_code in (200, 201):
+        _LOGGING.info("Dashboard uploaded successfully")
+    else:
+        _LOGGING.error("Failed (%s): %s", result.status_code, result.text)
+        sys.exit(1)

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -545,6 +545,45 @@ def get_config(ctx: Configuration) -> dict[str, Any]:
     raise HomeAssistantCliError(f"Error while getting all configuration: {req.text}")
 
 
+def get_dashboards(ctx: Configuration) -> list[dict[str, Any]]:
+    """Return list of all dashboards."""
+    frame = {"type": hass.WS_TYPE_LOVELACE_DASHBOARDS_LIST}
+    result = cast(dict, wsapi(ctx, frame))
+    return result["result"]
+
+
+def get_dashboard_config(ctx: Configuration, url_path: str = "") -> dict[str, Any]:
+    """Return a dashboard config as a raw dict."""
+    path = hass.URL_API_LOVELACE_CONFIG
+    if url_path:
+        path = f"{path}?url_path={url_path}"
+    try:
+        req = restapi(ctx, METH_GET, path)
+    except HomeAssistantCliError as exception:
+        raise HomeAssistantCliError(
+            f"Unexpected error retrieving dashboard config: {exception}"
+        ) from exception
+    if req.status_code == 200:
+        return cast(dict[str, Any], req.json())
+    raise HomeAssistantCliError(f"Error retrieving dashboard config: {req.text}")
+
+
+def save_dashboard_config(
+    ctx: Configuration, config: dict[str, Any], url_path: str = ""
+) -> requests.Response:
+    """Save a dashboard config."""
+    path = hass.URL_API_LOVELACE_CONFIG
+    if url_path:
+        path = f"{path}?url_path={url_path}"
+    try:
+        req = restapi(ctx, METH_POST, path, config)
+    except HomeAssistantCliError as exception:
+        raise HomeAssistantCliError(
+            f"Unexpected error saving dashboard config: {exception}"
+        ) from exception
+    return req
+
+
 def get_state(ctx: Configuration, entity_id: str) -> dict[str, Any] | None:
     """Get entity state. If ok, return dictionary with state.
 

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -583,6 +583,44 @@ def save_dashboard_config(
     return cast(dict[str, Any], result)
 
 
+def create_dashboard(
+    ctx: Configuration, url_path: str, title: str
+) -> dict[str, Any]:
+    """Create a new dashboard registry entry."""
+    frame: dict[str, Any] = {
+        "type": hass.WS_TYPE_LOVELACE_DASHBOARDS_CREATE,
+        "url_path": url_path,
+        "title": title,
+    }
+    result = cast(dict, wsapi(ctx, frame))
+    if not result.get("success"):
+        raise HomeAssistantCliError(
+            f"Error creating dashboard: {result.get('error', {}).get('message', 'unknown error')}"
+        )
+    return cast(dict[str, Any], result)
+
+
+def delete_dashboard(ctx: Configuration, url_path: str) -> dict[str, Any]:
+    """Delete a dashboard registry entry."""
+    dashboards = get_dashboards(ctx)
+    dashboard = next(
+        (d for d in dashboards if d.get("url_path") == url_path or d.get("id") == url_path),
+        None,
+    )
+    if not dashboard:
+        raise HomeAssistantCliError(f"Could not find dashboard with url_path or id: {url_path}")
+    frame: dict[str, Any] = {
+        "type": hass.WS_TYPE_LOVELACE_DASHBOARDS_DELETE,
+        "dashboard_id": dashboard["id"],
+    }
+    result = cast(dict, wsapi(ctx, frame))
+    if not result.get("success"):
+        raise HomeAssistantCliError(
+            f"Error deleting dashboard: {result.get('error', {}).get('message', 'unknown error')}"
+        )
+    return cast(dict[str, Any], result)
+
+
 def get_state(ctx: Configuration, entity_id: str) -> dict[str, Any] | None:
     """Get entity state. If ok, return dictionary with state.
 

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -560,7 +560,8 @@ def get_dashboard_config(ctx: Configuration, url_path: str = "") -> dict[str, An
     result = cast(dict, wsapi(ctx, frame))
     if not result.get("success"):
         raise HomeAssistantCliError(
-            f"Error retrieving dashboard config: {result.get('error', {}).get('message', 'unknown error')}"
+            f"Error retrieving dashboard config: "
+            f"{result.get('error', {}).get('message', 'unknown error')}"
         )
     return cast(dict[str, Any], result["result"])
 
@@ -578,7 +579,8 @@ def save_dashboard_config(
     result = cast(dict, wsapi(ctx, frame))
     if not result.get("success"):
         raise HomeAssistantCliError(
-            f"Error saving dashboard config: {result.get('error', {}).get('message', 'unknown error')}"
+            f"Error saving dashboard config: "
+            f"{result.get('error', {}).get('message', 'unknown error')}"
         )
     return cast(dict[str, Any], result)
 
@@ -595,7 +597,8 @@ def create_dashboard(
     result = cast(dict, wsapi(ctx, frame))
     if not result.get("success"):
         raise HomeAssistantCliError(
-            f"Error creating dashboard: {result.get('error', {}).get('message', 'unknown error')}"
+            f"Error creating dashboard: "
+            f"{result.get('error', {}).get('message', 'unknown error')}"
         )
     return cast(dict[str, Any], result)
 
@@ -604,11 +607,17 @@ def delete_dashboard(ctx: Configuration, url_path: str) -> dict[str, Any]:
     """Delete a dashboard registry entry."""
     dashboards = get_dashboards(ctx)
     dashboard = next(
-        (d for d in dashboards if d.get("url_path") == url_path or d.get("id") == url_path),
+        (
+            d
+            for d in dashboards
+            if d.get("url_path") == url_path or d.get("id") == url_path
+        ),
         None,
     )
     if not dashboard:
-        raise HomeAssistantCliError(f"Could not find dashboard with url_path or id: {url_path}")
+        raise HomeAssistantCliError(
+            f"Could not find dashboard with url_path or id: {url_path}"
+        )
     frame: dict[str, Any] = {
         "type": hass.WS_TYPE_LOVELACE_DASHBOARDS_DELETE,
         "dashboard_id": dashboard["id"],
@@ -616,7 +625,8 @@ def delete_dashboard(ctx: Configuration, url_path: str) -> dict[str, Any]:
     result = cast(dict, wsapi(ctx, frame))
     if not result.get("success"):
         raise HomeAssistantCliError(
-            f"Error deleting dashboard: {result.get('error', {}).get('message', 'unknown error')}"
+            f"Error deleting dashboard: "
+            f"{result.get('error', {}).get('message', 'unknown error')}"
         )
     return cast(dict[str, Any], result)
 

--- a/homeassistant_cli/remote.py
+++ b/homeassistant_cli/remote.py
@@ -554,34 +554,33 @@ def get_dashboards(ctx: Configuration) -> list[dict[str, Any]]:
 
 def get_dashboard_config(ctx: Configuration, url_path: str = "") -> dict[str, Any]:
     """Return a dashboard config as a raw dict."""
-    path = hass.URL_API_LOVELACE_CONFIG
+    frame: dict[str, Any] = {"type": hass.WS_TYPE_LOVELACE_CONFIG_GET}
     if url_path:
-        path = f"{path}?url_path={url_path}"
-    try:
-        req = restapi(ctx, METH_GET, path)
-    except HomeAssistantCliError as exception:
+        frame["url_path"] = url_path
+    result = cast(dict, wsapi(ctx, frame))
+    if not result.get("success"):
         raise HomeAssistantCliError(
-            f"Unexpected error retrieving dashboard config: {exception}"
-        ) from exception
-    if req.status_code == 200:
-        return cast(dict[str, Any], req.json())
-    raise HomeAssistantCliError(f"Error retrieving dashboard config: {req.text}")
+            f"Error retrieving dashboard config: {result.get('error', {}).get('message', 'unknown error')}"
+        )
+    return cast(dict[str, Any], result["result"])
 
 
 def save_dashboard_config(
     ctx: Configuration, config: dict[str, Any], url_path: str = ""
-) -> requests.Response:
+) -> dict[str, Any]:
     """Save a dashboard config."""
-    path = hass.URL_API_LOVELACE_CONFIG
+    frame: dict[str, Any] = {
+        "type": hass.WS_TYPE_LOVELACE_CONFIG_SAVE,
+        "config": config,
+    }
     if url_path:
-        path = f"{path}?url_path={url_path}"
-    try:
-        req = restapi(ctx, METH_POST, path, config)
-    except HomeAssistantCliError as exception:
+        frame["url_path"] = url_path
+    result = cast(dict, wsapi(ctx, frame))
+    if not result.get("success"):
         raise HomeAssistantCliError(
-            f"Unexpected error saving dashboard config: {exception}"
-        ) from exception
-    return req
+            f"Error saving dashboard config: {result.get('error', {}).get('message', 'unknown error')}"
+        )
+    return cast(dict[str, Any], result)
 
 
 def get_state(ctx: Configuration, entity_id: str) -> dict[str, Any] | None:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -5,12 +5,10 @@ import pytest
 from homeassistant_cli.cli import HomeAssistantCli, cli
 
 DFEAULT_PLUGINS = [
-    "area",
     "completion",
     "config",
-    "dashboard",
-    "device",
     "discover",
+    "state",
     "entity",
     "event",
     "ha",
@@ -19,9 +17,11 @@ DFEAULT_PLUGINS = [
     "map",
     "raw",
     "service",
-    "state",
     "system",
     "template",
+    "area",
+    "device",
+    "dashboard",
 ]
 
 DFEAULT_PLUGINS.sort()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -5,10 +5,12 @@ import pytest
 from homeassistant_cli.cli import HomeAssistantCli, cli
 
 DFEAULT_PLUGINS = [
+    "area",
     "completion",
     "config",
+    "dashboard",
+    "device",
     "discover",
-    "state",
     "entity",
     "event",
     "ha",
@@ -17,10 +19,9 @@ DFEAULT_PLUGINS = [
     "map",
     "raw",
     "service",
+    "state",
     "system",
     "template",
-    "area",
-    "device",
 ]
 
 DFEAULT_PLUGINS.sort()


### PR DESCRIPTION
## Summary

- Adds a new \`hass-cli dashboard\` plugin with three commands: \`list\`, \`get\`, and \`set\`
- All three commands use the WebSocket API (\`lovelace/dashboards/list\`, \`lovelace/config\`, \`lovelace/config/save\`) for consistency and compatibility with HA instances that have no default Lovelace dashboard
- Named dashboards are supported via an optional \`url_path\` argument on \`get\` and \`set\`
- Follows the same plugin architecture and patterns as existing commands (e.g. \`area\`, \`state\`)

## Usage

```bash
hass-cli dashboard list
hass-cli dashboard get                          # default dashboard → stdout
hass-cli dashboard get my-dashboard             # named dashboard
hass-cli dashboard get > lovelace.yaml          # redirect to file
hass-cli dashboard set lovelace.yaml            # upload to default
hass-cli dashboard set lovelace.yaml my-dash    # upload to named dashboard
```

## Test plan

- [x] \`hass-cli dashboard list\` returns a table of dashboards
- [x] \`hass-cli dashboard get my-dashboard\` returns config for a named dashboard
- [x] \`hass-cli dashboard get > /tmp/lv.yaml\` produces a valid YAML file
- [x] \`hass-cli dashboard set /tmp/lv.yaml my-dashboard\` round-trips without error
- [x] \`hass-cli dashboard --help\` appears in top-level command list
- [x] All existing tests pass (\`pytest tests/\`)